### PR TITLE
✨ feat(image error): 이미지 에러 체크 커스텀 훅

### DIFF
--- a/src/app/(boards)/boards/[id]/components/CommentList.tsx
+++ b/src/app/(boards)/boards/[id]/components/CommentList.tsx
@@ -9,6 +9,7 @@ import DeleteIcon from "@/assets/icons/trashIcon.svg";
 import { ICommentList } from "@/apis/comment/getComment";
 import dayjs from "dayjs";
 import Image from "next/image";
+import useImageLoad from "@/hooks/useImageLoad";
 import deleteComment from "@/apis/comment/deleteComment";
 import patchComment from "@/apis/comment/patchComment";
 import CommonModal from "@/_components/CommonModal";
@@ -30,6 +31,7 @@ function CommentList({ list, myId, onChangeApi }: ICommentListProps) {
   const [commentCount, setCommentCount] = useState(content.length);
   const isMyComment = writerId === myId;
   const formattedDate = dayjs(createdAt).format("YYYY.MM.DD.");
+  const imageError = useImageLoad(image);
 
   const handleViewModal = () => {
     setViewModal(!viewModal);
@@ -71,10 +73,10 @@ function CommentList({ list, myId, onChangeApi }: ICommentListProps) {
     <>
       <li className="flex gap-[15px] rounded-[10px] px-5 py-4 shadow-custom-shadow sm:gap-5 sm:px-[30px] sm:py-5 lg:py-[22px]">
         <div className="flex h-10 w-10 overflow-hidden rounded-full sm:h-[50px] sm:w-[50px]">
-          {image ? (
+          {imageError === false && image ? (
             <Image src={image} alt={name} style={{ objectFit: "cover" }} />
           ) : (
-            <DefaultProfile width="100%" height="100%" />
+            imageError === true && <DefaultProfile width="100%" height="100%" />
           )}
         </div>
         <div className="flex-1">

--- a/src/hooks/useImageLoad.ts
+++ b/src/hooks/useImageLoad.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+const useImageLoad = (imageUrl: string | null) => {
+  const [imgError, setImgError] = useState<boolean | undefined>();
+
+  useEffect(() => {
+    if (!imageUrl) {
+      setImgError(true);
+      return;
+    }
+
+    const img = new Image();
+    img.src = imageUrl;
+
+    img.onload = () => {
+      setImgError(false);
+    };
+
+    img.onerror = () => {
+      setImgError(true);
+    };
+  }, [imageUrl]);
+
+  return imgError;
+};
+
+export default useImageLoad;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## ✅ 작업 사항
- 이미지 에러 처리하는 커스텀 훅 추가했습니다!

## 👩‍💻 공유 포인트 및 논의 사항

<b>사용법</b>
1. api에서 받아온 이미지 url을 useImageLoad 훅에 넣어주세요
2. 프로필 없을 때 보여야 할 디폴트 이미지 import (다른 페이지랑 통일 위해 @/assets/icons/defaultProfile.svg 요걸로 사용해주세요)
3. 조건부 렌더링 해주세요! (조건에 !imageError 이렇게 하면 안되고 imageError === false 이렇게 해야 됩니닷)
4. 예시 코드 참고해주세요!


```
import useImageLoad from "@/hooks/useImageLoad";
import DefaultProfile from "@/assets/icons/defaultProfile.svg";

const imageError = useImageLoad(image);

<div>
  {imageError === false && image ? (
    <Image src={image} alt={name} style={{ objectFit: "cover" }} /> // 프로필 있을 경우 보일 이미지
  ) : (
    imageError === true && <DefaultProfile width="100%" height="100%" /> // 프로필 없을 경우 보여주는 디폴트 이미지
  )}
</div>
```